### PR TITLE
Making ansible roles work with ansible galaxy

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,7 +2,7 @@
 galaxy_info:
   author: Pontus Larsson
   description: Hercules is a system for managing sequencing data in the context of a sequencing facility.
-  company: SNP&SEQ Technology Platform, Dept. of Medical Sciences, Uppsala University, SWEDEN
+  company: SNP&SEQ Technology Platform
   license: "mit"
   min_ansible_version: 1.7
   platforms:


### PR DESCRIPTION
I was in contact with the ansible-galaxy support and they recommended that I changed the licence to "mit" and had fewer characters in the "Company name". I did those things and I was then able to import the role.
