### PR TITLE
Making the process channel default for notifications

### DIFF
--- a/templates/hercules.j2
+++ b/templates/hercules.j2
@@ -37,7 +37,7 @@ notifications {
     smtp_host = "{{ notification_smtp_host  }}"
     smtp_port = {{ notification_smtp_port  }}
     prefix = "[Hercules]"
-    channels = ["critical"]
+    channels = ["critical", "progress"]
     retry_interval = 60
     # 0 = infinite retries
     num_retries = 0  


### PR DESCRIPTION
It would be nice to get the progress e-mails by default, so I added that as a channel in the email config.